### PR TITLE
import Vue into Vuemit class

### DIFF
--- a/src/Vuemit.js
+++ b/src/Vuemit.js
@@ -6,6 +6,8 @@
  * @license https://github.com/gocanto/vuemit/blob/master/LICENSE
  */
 
+import Vue from 'vue';
+
 class Vuemit
 {
 	/**


### PR DESCRIPTION
Vue is not necessarily always attached to the window. That said, it's better to import it at the class level.