### PR TITLE
change dep to devdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "events",
     "handler"
   ],
-  "dependencies": {
+  "devDependencies": {
     "ava": "^0.18.0",
     "babel-preset-env": "^1.6",
     "babel-preset-stage-3": "^6.24.1",


### PR DESCRIPTION
according to https://github.com/siddharthkp/cost-of-modules the package size was 95.67M.

so changing the dep to devDep, the package is now 0.25M.

also testing with build scripts `watch, production` in laravel didnt show any issues.

also check https://arve0.github.io/npm-download-size/#vue-notif