### PR TITLE
fix Cannot assign to read only property 'exports' of object '#<Object>'

### DIFF
--- a/src/Vuemit.js
+++ b/src/Vuemit.js
@@ -6,7 +6,7 @@
  * @license https://github.com/gocanto/vuemit/blob/master/LICENSE
  */
 
-import Vue from 'vue'
+const Vue = require('vue')
 
 class Vuemit
 {


### PR DESCRIPTION
according to https://github.com/webpack/webpack/issues/4039#issuecomment-273804003, now the issue is gone 🎉 