### PR TITLE
Update Vuemit.js

### DIFF
--- a/src/Vuemit.js
+++ b/src/Vuemit.js
@@ -6,7 +6,7 @@
  * @license https://github.com/gocanto/vuemit/blob/master/LICENSE
  */
 
-const Vue = require('vue')
+const Vue = require('vue').default
 
 class Vuemit
 {


### PR DESCRIPTION
to fix issues with new wp 5 where we will get `Uncaught TypeError: Vue is not a constructor`, 

note that this might break current setups, so better release a new major version.